### PR TITLE
Missing steps to properly run locally on a clean system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ NSHipster runs on [Jekyll](https://github.com/mojombo/jekyll), a blog-aware, sta
 
 ``` shell
 $ cd path/to/nshipster.com
+$ gem install bundler
+$ bundle install
 $ gem install jekyll
 $ jekyll --auto --server
 ```


### PR DESCRIPTION
Added two steps in the `Running Locally` section of the README to install Bundler and run it against the provided Gemfile because as it were, jekyll was refusing to properly start.
