### PR TITLE
Minor associated objects fix

### DIFF
--- a/_posts/2012-12-31-reader-submissions-new-years-2013.md
+++ b/_posts/2012-12-31-reader-submissions-new-years-2013.md
@@ -31,7 +31,7 @@ Categories are a well-known feature of Objective-C, allowing new methods to be a
     #import "NSObject+Extension.h"
     #import <objc/runtime.h>
 
-    static char const * const IndieBandNameKey = "IndieBandName";    
+    static const void *IndieBandNameKey = &IndieBandNameKey;    
 
     @implementation NSObject (IndieBandName)
     @dynamic indieBandName;


### PR DESCRIPTION
Associated objects use void pointers for their keys. Attached to the pull request is a good way to guarantee uniqueness (hat tip to Mike Ash for showing this to me first).
