### PR TITLE
Fixed broken author url

### DIFF
--- a/nshipster.com/_data/authors.yml
+++ b/nshipster.com/_data/authors.yml
@@ -10,7 +10,7 @@
 "Mike Lazer-Walker":
   name: Mike Lazer-Walker
   email: michael@lazerwalker.com
-  url: http:/twitter.com/lazerwalker
+  url: https://twitter.com/lazerwalker
   twitter: lazerwalker
   github: lazerwalker
   google: ""


### PR DESCRIPTION
A link to Mike's twitter page would lead [here](http://nshipster.com/twitter.com/lazerwalker) instead of [here](https://twitter.com/lazerwalker).
